### PR TITLE
Completing work for 14393 analysis

### DIFF
--- a/DemoUWP_CS/DemoUWP_CS.csproj
+++ b/DemoUWP_CS/DemoUWP_CS.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>DemoUWP_CS</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
@@ -127,10 +127,10 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="WindowsDesktop, Version=10.0.10586.0">
+    <SDKReference Include="WindowsDesktop, Version=10.0.14393.0">
       <Name>Windows Desktop Extensions for the UWP</Name>
     </SDKReference>
-    <SDKReference Include="WindowsMobile, Version=10.0.10586.0">
+    <SDKReference Include="WindowsMobile, Version=10.0.14393.0">
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>

--- a/DemoUWP_CS/MainPage.xaml
+++ b/DemoUWP_CS/MainPage.xaml
@@ -1,18 +1,43 @@
-﻿<Page
-    x:Class="DemoUWP_CS.MainPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:DemoUWP_CS"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+﻿<Page x:Class="DemoUWP_CS.MainPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:DemoUWP_CS"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
 
     <StackPanel Background="LightBlue">
-        <TextBlock x:Name="label1" FontSize="30" Text="DemoUWP_CS"/>
-        <Image x:Name="image1" Width="100" Height="100" HorizontalAlignment="Left"/>
-        <Button x:Name="buttonMobile" FontSize="20" Content="MobileSDK" Margin="4" Click="buttonMobile_Click"/>
-        <Button x:Name="buttonMobileDesktop" FontSize="20" Content="MobileSDK+DesktopSDK" Margin="4" Click="buttonMobileDesktop_Click"/>
-        <Button x:Name="buttonDesktop" FontSize="20" Content="DesktopSDK" Margin="4" Click="buttonDesktop_Click"/>
-        <Button x:Name="button10586" FontSize="20" Content="10586 SDK" Margin="4" Click="button10586_Click"/>
+        <TextBlock x:Name="label1"
+                   FontSize="30"
+                   Text="DemoUWP_CS" />
+        <Image x:Name="image1"
+               Width="100"
+               Height="100"
+               HorizontalAlignment="Left" />
+        <Button x:Name="buttonMobile"
+                FontSize="20"
+                Content="MobileSDK"
+                Margin="4"
+                Click="buttonMobile_Click" />
+        <Button x:Name="buttonMobileDesktop"
+                FontSize="20"
+                Content="MobileSDK+DesktopSDK"
+                Margin="4"
+                Click="buttonMobileDesktop_Click" />
+        <Button x:Name="buttonDesktop"
+                FontSize="20"
+                Content="DesktopSDK"
+                Margin="4"
+                Click="buttonDesktop_Click" />
+        <Button x:Name="button10586"
+                FontSize="20"
+                Content="10586 SDK"
+                Margin="4"
+                Click="button10586_Click" />
+        <Button x:Name="button14393"
+                FontSize="20"
+                Content="14393 SDK"
+                Margin="4"
+                Click="button14393_Click" />
     </StackPanel>
 </Page>

--- a/DemoUWP_CS/MainPage.xaml.cs
+++ b/DemoUWP_CS/MainPage.xaml.cs
@@ -1,21 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
 using Windows.Media.Devices;
 using Windows.System.UserProfile;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Imaging;
-using Windows.UI.Xaml.Navigation;
 
 namespace DemoUWP_CS
 {
@@ -70,6 +59,11 @@ namespace DemoUWP_CS
             var jumps = Windows.UI.StartScreen.JumpList.IsSupported();
             Windows.ApplicationModel.Store.Preview.StoreConfiguration.PurchasePromptingPolicy = null;
             var size = Windows.Graphics.Display.DisplayInformation.GetForCurrentView().DiagonalSizeInInches;
+        }
+
+        private void button14393_Click(object sender, RoutedEventArgs e)
+        {
+            Windows.ApplicationModel.Core.CoreApplication.EnablePrelaunch(true);
         }
     }
 }

--- a/DemoUWP_VB/DemoUWP_VB.vbproj
+++ b/DemoUWP_VB/DemoUWP_VB.vbproj
@@ -10,7 +10,7 @@
     <AssemblyName>DemoUWP_VB</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.10586.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.14393.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.10240.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
@@ -165,12 +165,15 @@
     <Import Include="Windows.UI.Xaml.Navigation" />
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="WindowsDesktop, Version=10.0.10586.0">
+    <SDKReference Include="WindowsDesktop, Version=10.0.14393.0">
       <Name>Windows Desktop Extensions for the UWP</Name>
     </SDKReference>
-    <SDKReference Include="WindowsMobile, Version=10.0.10586.0">
+    <SDKReference Include="WindowsMobile, Version=10.0.14393.0">
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\PlatformSpecificAnalyzer\bin\Debug\PlatformSpecificAnalyzer.dll" />
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>

--- a/DemoUWP_VB/MainPage.xaml
+++ b/DemoUWP_VB/MainPage.xaml
@@ -1,18 +1,38 @@
-﻿<Page
-    x:Class="DemoUWP_VB.MainPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:DemoUWP_VB"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d">
+﻿<Page x:Class="DemoUWP_VB.MainPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:DemoUWP_VB"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="d">
 
     <StackPanel Background="LightBlue">
-        <TextBlock x:Name="label1" FontSize="30" Text="DemoUWP_VB"/>
-        <Image x:Name="image1" Width="100" Height="100" HorizontalAlignment="Left"/>
-        <Button x:Name="buttonMobile" FontSize="20" Content="MobileSDK" Margin="4"/>
-        <Button x:Name="buttonMobileDesktop" FontSize="20" Content="MobileSDK+DesktopSDK" Margin="4"/>
-        <Button x:Name="buttonDesktop" FontSize="20" Content="DesktopSDK" Margin="4"/>
-        <Button x:Name="button10586" FontSize="20" Content="10586 SDK" Margin="4"/>
+        <TextBlock x:Name="label1"
+                   FontSize="30"
+                   Text="DemoUWP_VB" />
+        <Image x:Name="image1"
+               Width="100"
+               Height="100"
+               HorizontalAlignment="Left" />
+        <Button x:Name="buttonMobile"
+                FontSize="20"
+                Content="MobileSDK"
+                Margin="4" />
+        <Button x:Name="buttonMobileDesktop"
+                FontSize="20"
+                Content="MobileSDK+DesktopSDK"
+                Margin="4" />
+        <Button x:Name="buttonDesktop"
+                FontSize="20"
+                Content="DesktopSDK"
+                Margin="4" />
+        <Button x:Name="button10586"
+                FontSize="20"
+                Content="10586 SDK"
+                Margin="4" />
+        <Button x:Name="button14393"
+                FontSize="20"
+                Content="14393 SDK"
+                Margin="4" />
     </StackPanel>
 </Page>

--- a/DemoUWP_VB/MainPage.xaml.vb
+++ b/DemoUWP_VB/MainPage.xaml.vb
@@ -36,5 +36,9 @@ Public NotInheritable Class MainPage
         Dim jumps = Windows.UI.StartScreen.JumpList.IsSupported()
         Dim size = Windows.Graphics.Display.DisplayInformation.GetForCurrentView().DiagonalSizeInInches
     End Sub
+
+    Private Sub button14393_Click(sender As Object, e As RoutedEventArgs) Handles button14393.Click
+        Windows.ApplicationModel.Core.CoreApplication.EnablePrelaunch(True)
+    End Sub
 End Class
 

--- a/PlatformSpecificAnalyzer/My Project/AssemblyInfo.vb
+++ b/PlatformSpecificAnalyzer/My Project/AssemblyInfo.vb
@@ -1,0 +1,36 @@
+﻿Imports System.Resources
+Imports System
+Imports System.Reflection
+Imports System.Runtime.InteropServices
+
+' General Information about an assembly is controlled through the following 
+' set of attributes. Change these attribute values to modify the information
+' associated with an assembly.
+
+' Review the values of the assembly attributes
+
+<Assembly: AssemblyTitle("Platform Specific Analyzer")>
+<Assembly: AssemblyDescription("This analyzer detects where you're using platform- and version-specific (non-universal) Windows 10 UWP APIs, and helps you guard them correctly.")>
+<Assembly: AssemblyCompany("")>
+<Assembly: AssemblyProduct("Platform Specific Analyzer")>
+<Assembly: AssemblyCopyright("Copyright ©  2016")>
+<Assembly: AssemblyTrademark("")>
+
+<Assembly: ComVisible(True)>
+
+'The following GUID is for the ID of the typelib if this project is exposed to COM
+<Assembly: Guid("701b5213-d6ba-42cb-91f0-1de629cab512")>
+
+' Version information for an assembly consists of the following four values:
+'
+'      Major Version
+'      Minor Version 
+'      Build Number
+'      Revision
+'
+' You can specify all the values or you can default the Build and Revision Numbers 
+' by using the '*' as shown below:
+
+<Assembly: AssemblyVersion("2.10.14393")>
+<Assembly: AssemblyFileVersion("2.10.14393")>
+<Assembly: NeutralResourcesLanguage("en-US")>

--- a/PlatformSpecificAnalyzer/PlatformSpecificAnalyzer.vb
+++ b/PlatformSpecificAnalyzer/PlatformSpecificAnalyzer.vb
@@ -21,7 +21,7 @@ End Enum
 
 Public Structure Platform
     Public Kind As PlatformKind
-    Public Version As String ' For UWP, this is version 10240 or 10586. For User, the fully qualified name of the attribute in use
+    Public Version As String ' For UWP, this is version 10240, 10586, or 14393. For User, the fully qualified name of the attribute in use
     Public ByParameterCount As Boolean ' For UWP only
 
     Public Sub New(kind As PlatformKind, Optional version As String = Nothing, Optional byParameterCount As Boolean = False)
@@ -30,7 +30,7 @@ Public Structure Platform
         Me.ByParameterCount = byParameterCount
         Select Case kind
             Case PlatformKind.Unchecked : If version IsNot Nothing Then Throw New ArgumentException("No version expected")
-            Case PlatformKind.Uwp : If version <> "10240" AndAlso version <> "10586" Then Throw New ArgumentException("Only known SDKs are 10240 and 10586")
+            Case PlatformKind.Uwp : If version <> "10240" AndAlso version <> "10586" AndAlso version <> "14393" Then Throw New ArgumentException("Only known SDKs are 10240, 10586, and 14393")
             Case PlatformKind.ExtensionSDK : If version IsNot Nothing Then Throw New ArgumentException("Don't specify versions for extension SDKs")
             Case PlatformKind.User : If Not version?.EndsWith("Specific") Then Throw New ArgumentException("User specific should end in Specific")
         End Select
@@ -108,9 +108,9 @@ Public Structure Platform
 
     Private Shared Function CheckCollectionForType(collection As Dictionary(Of String, List(Of NewMember)), typeName As String, symbol As ISymbol) As Int16
         Dim newMembers As List(Of NewMember) = Nothing
-        Dim in10586 = collection.TryGetValue(typeName, newMembers)
+        Dim inCollection = collection.TryGetValue(typeName, newMembers)
 
-        If newMembers Is Nothing Then Return 0 ' the entire type was new in this collection
+        If Not inCollection Or newMembers Is Nothing Then Return 0 ' the entire type was new in this collection
 
         If symbol.Kind = SymbolKind.NamedType Then Return -1
 

--- a/PlatformSpecificAnalyzer/PlatformSpecificAnalyzer.vb
+++ b/PlatformSpecificAnalyzer/PlatformSpecificAnalyzer.vb
@@ -170,8 +170,17 @@ End Class
 
 
 Module PlatformSpecificAnalyzer
-    Public RulePlatform As New DiagnosticDescriptor("UWP001", "Platform-specific", "Platform-specific code", "Safety", DiagnosticSeverity.Warning, True)
-    Public RuleVersion As New DiagnosticDescriptor("UWP002", "Version-specific", "Version-specific code", "Safety", DiagnosticSeverity.Warning, True)
+    Public Function CreatePlatformRule(targetPlatform As Platform) As DiagnosticDescriptor
+        Return New DiagnosticDescriptor("UWP001", "Platform-specific", $"Platform-specific code ({targetPlatform.Kind})",
+                                        "Safety", DiagnosticSeverity.Warning, True)
+    End Function
+
+    Public Function CreateVersionRule(targetPlatform As Platform) As DiagnosticDescriptor
+        Return New DiagnosticDescriptor("UWP002", "Version-specific", $"Version-specific code ({targetPlatform.Version})",
+                                        "Safety", DiagnosticSeverity.Warning, True)
+    End Function
+    Public GenericRulePlatform As New DiagnosticDescriptor("UWP001", "Platform-specific", "Platform-specific code", "Safety", DiagnosticSeverity.Warning, True)
+    Public GenericRuleVersion As New DiagnosticDescriptor("UWP002", "Version-specific", "Version-specific code", "Safety", DiagnosticSeverity.Warning, True)
 
     Function GetTargetPlatformMinVersion(additionalFiles As ImmutableArray(Of AdditionalText)) As Integer
         ' When PlatformSpecificAnalyzer is build as a NuGet package, the package includes

--- a/PlatformSpecificAnalyzer/PlatformSpecificAnalyzer.vbproj
+++ b/PlatformSpecificAnalyzer/PlatformSpecificAnalyzer.vbproj
@@ -130,13 +130,12 @@
     <None Include="nupkg\PlatformSpecificAnalyzer.png" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="My Project\AssemblyInfo.vb" />
     <Compile Include="PlatformSpecificAnalyzer.vb" />
     <Compile Include="PlatformSpecificAnalyzerCS.vb" />
     <Compile Include="PlatformSpecificAnalyzerVB.vb" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="My Project\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <ProjectReference Include="..\PlatformSpecific\PlatformSpecific.vbproj">
       <Project>{25ec45af-4df8-4c3b-b5e2-e3a23dbac14f}</Project>

--- a/PlatformSpecificAnalyzer/PlatformSpecificAnalyzerCS.vb
+++ b/PlatformSpecificAnalyzer/PlatformSpecificAnalyzerCS.vb
@@ -18,7 +18,7 @@ Public Class PlatformSpecificAnalyzerCS
 
     Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
         Get
-            Return ImmutableArray.Create(RulePlatform, RuleVersion)
+            Return ImmutableArray.Create(GenericRulePlatform, GenericRuleVersion)
         End Get
     End Property
 
@@ -84,7 +84,7 @@ Public Class PlatformSpecificAnalyzerCS
         If Not loc.IsInSource Then Return
         Dim line = loc.GetLineSpan().StartLinePosition.Line
         If reports.ContainsKey(line) AndAlso reports(line).Location.SourceSpan.Start <= loc.SourceSpan.Start Then Return
-        reports(line) = Diagnostic.Create(If(plat.Kind = PlatformKind.Uwp, RuleVersion, RulePlatform), loc)
+        reports(line) = Diagnostic.Create(If(plat.Kind = PlatformKind.Uwp, CreateVersionRule(plat), CreatePlatformRule(plat)), loc)
     End Sub
 
 

--- a/PlatformSpecificAnalyzer/PlatformSpecificAnalyzerVB.vb
+++ b/PlatformSpecificAnalyzer/PlatformSpecificAnalyzerVB.vb
@@ -18,7 +18,7 @@ Public Class PlatformSpecificAnalyzerVB
 
     Public Overrides ReadOnly Property SupportedDiagnostics As ImmutableArray(Of DiagnosticDescriptor)
         Get
-            Return ImmutableArray.Create(RulePlatform, RuleVersion)
+            Return ImmutableArray.Create(GenericRulePlatform, GenericRuleVersion)
         End Get
     End Property
 
@@ -84,7 +84,7 @@ Public Class PlatformSpecificAnalyzerVB
         If Not loc.IsInSource Then Return
         Dim line = loc.GetLineSpan().StartLinePosition.Line
         If reports.ContainsKey(line) AndAlso reports(line).Location.SourceSpan.Start <= loc.SourceSpan.Start Then Return
-        reports(line) = Diagnostic.Create(If(plat.Kind = PlatformKind.Uwp, RuleVersion, RulePlatform), loc)
+        reports(line) = Diagnostic.Create(If(plat.Kind = PlatformKind.Uwp, CreateVersionRule(plat), CreatePlatformRule(plat)), loc)
     End Sub
 
     Shared Function GetTargetOfNode(node As SyntaxNode, sm As SemanticModel) As ISymbol

--- a/PlatformSpecificAnalyzer/nupkg/PlatformSpecificAnalyzer.nuspec
+++ b/PlatformSpecificAnalyzer/nupkg/PlatformSpecificAnalyzer.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>PlatformSpecific.Analyzer</id>
-    <version>2.0.3</version>
+    <version>2.10.14393</version>
     <title>Platform Specific Analyzer</title>
     <authors>Lucian Wischik</authors>
     <owners>Lucian Wischik</owners>


### PR DESCRIPTION
- Bumped the `nupkg` version
- Made analyzer spit out more useful warnings (eg: **what** version a call is specific to)
- Update Demo apps with analyzer and 14393-specific calls to illustrate the warnings for 14393
